### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/ChartboostAdapter.swift
+++ b/Source/ChartboostAdapter.swift
@@ -47,9 +47,8 @@ final class ChartboostAdapter: PartnerAdapter {
         // Start Chartboost
         Chartboost.start(withAppID: appID, appSignature: appSignature) { [self] partnerError in
             if let partnerError = partnerError {
-                let error = self.error(.initializationFailureUnknown, error: partnerError)
-                log(.setUpFailed(error))
-                completion(error)
+                log(.setUpFailed(partnerError))
+                completion(partnerError)
             } else {
                 log(.setUpSucceded)
                 completion(nil)

--- a/Source/ChartboostAdapterAd.swift
+++ b/Source/ChartboostAdapterAd.swift
@@ -104,9 +104,8 @@ extension ChartboostAdapterAd: CHBInterstitialDelegate, CHBRewardedDelegate, CHB
     func didCacheAd(_ event: CHBCacheEvent, error partnerError: CHBCacheError?) {
         // Report load finished
         if let partnerError = partnerError {
-            let error = error(.loadFailureUnknown, error: partnerError)
-            log(.loadFailed(error))
-            loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+            log(.loadFailed(partnerError))
+            loadCompletion?(.failure(partnerError)) ?? log(.loadResultIgnored)
         } else {
             log(.loadSucceeded)
             loadCompletion?(.success([:])) ?? log(.loadResultIgnored)
@@ -121,9 +120,8 @@ extension ChartboostAdapterAd: CHBInterstitialDelegate, CHBRewardedDelegate, CHB
     func didShowAd(_ event: CHBShowEvent, error partnerError: CHBShowError?) {
         // Report show finished
         if let partnerError = partnerError {
-            let error = error(.showFailureUnknown, error: partnerError)
-            log(.showFailed(error))
-            showCompletion?(.failure(error)) ?? log(.showResultIgnored)
+            log(.showFailed(partnerError))
+            showCompletion?(.failure(partnerError)) ?? log(.showResultIgnored)
         } else {
             log(.showSucceeded)
             showCompletion?(.success([:])) ?? log(.showResultIgnored)


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
