### PR TITLE
HB-5026: revert temp changes

### DIFF
--- a/Source/ChartboostAdapter.swift
+++ b/Source/ChartboostAdapter.swift
@@ -67,14 +67,13 @@ final class ChartboostAdapter: PartnerAdapter {
     func fetchBidderInformation(request: PreBidRequest, completion: @escaping ([String : String]?) -> Void) {
         // Chartboost does not currently provide any bidding token
         log(.fetchBidderInfoStarted(request))
-//        if
-            let bidderToken = Chartboost.bidderToken() //{
+        if let bidderToken = Chartboost.bidderToken() {
             log(.fetchBidderInfoSucceeded(request))
             completion(["buyeruid": bidderToken])
-//        } else {
-//            log(.fetchBidderInfoFailed(request, error: error(.prebidFailureUnknown)))
-//            completion(nil)
-//        }
+        } else {
+            log(.fetchBidderInfoFailed(request, error: error(.prebidFailureUnknown)))
+            completion(nil)
+        }
     }
     
     /// Creates a new ad object in charge of communicating with a single partner SDK ad instance.


### PR DESCRIPTION
I needed this changes local for the Chartboost SDK 9.2.0 RC5 API changes addressed by https://github.com/ChartBoost/chartboost-mediation-ios-adapter-chartboost/pull/16.

Original commit to revert: https://github.com/ChartBoost/chartboost-mediation-ios-adapter-chartboost/commit/185064a72d93a69b0315a17ef6de3870bf08b44a