### PR TITLE
Update minimum iOS version for CB 9.2.0

### DIFF
--- a/ChartboostMediationAdapterChartboost.podspec
+++ b/ChartboostMediationAdapterChartboost.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
 
   # Minimum supported versions
   spec.swift_version         = '5.0'
-  spec.ios.deployment_target = '10.0'
+  spec.ios.deployment_target = '11.0'
 
   # System frameworks used
   spec.ios.frameworks = ['Foundation', 'SafariServices', 'UIKit', 'WebKit']

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Chartboost Mediation Chartboost adapter mediates Chartboost via the Chartboo
 | ------ | ------ |
 | Chartboost Mediation SDK | 4.0.0+ |
 | Cocoapods | 1.11.3+ |
-| iOS | 10.0+ |
+| iOS | 11.0+ |
 | Xcode | 14.1+ |
 
 ## Integration


### PR DESCRIPTION
Adapter min iOS version must match Chartboost SDK's, which changed on 9.2.0 to iOS 11.0.
This mismatch is causing lint failures in our nightly workflow:
<img width="1142" alt="Screen Shot 2023-02-13 at 12 07 22 PM" src="https://user-images.githubusercontent.com/9442254/218442070-b6fc7efd-69b5-4590-ad2f-53519c4617fc.png">

Btw this kind of issue will be caught earlier once we merge the smoke test workflow to the adapter repos.