### PR TITLE
Fix GitHub release step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 env:
+  GITHUB_TOKEN: ${{ secrets.GITHUBSERVICETOKEN }}
   COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
 jobs:


### PR DESCRIPTION
Add GitHub token to the environment to fix the last step in the release.yml which failed during the last release.