### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/Source/ChartboostAdapter.swift
+++ b/Source/ChartboostAdapter.swift
@@ -11,19 +11,27 @@ import Foundation
 final class ChartboostAdapter: PartnerAdapter {
     
     /// The version of the partner SDK.
-    let partnerSDKVersion = Chartboost.getSDKVersion()
-    
+    var partnerSDKVersion: String {
+        ChartboostAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.9.7.0.0"
-    
+    var adapterVersion: String {
+        ChartboostAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "chartboost"
-    
+    var partnerID: String {
+        ChartboostAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "Chartboost"
-    
+    var partnerDisplayName: String {
+        ChartboostAdapterConfiguration.partnerDisplayName
+    }
+
     /// The designated initializer for the adapter.
     /// Chartboost Mediation SDK will use this constructor to create instances of conforming types.
     /// - parameter storage: An object that exposes storage managed by the Chartboost Mediation SDK to the adapter.

--- a/Source/ChartboostAdapterConfiguration.swift
+++ b/Source/ChartboostAdapterConfiguration.swift
@@ -10,18 +10,18 @@ import Foundation
 @objc public class ChartboostAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         Chartboost.getSDKVersion()
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.9.7.0.0"
+    @objc public static let adapterVersion = "4.9.7.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "chartboost"
+    @objc public static let partnerID = "chartboost"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "Chartboost"
+    @objc public static let partnerDisplayName = "Chartboost"
 }

--- a/Source/ChartboostAdapterConfiguration.swift
+++ b/Source/ChartboostAdapterConfiguration.swift
@@ -1,0 +1,27 @@
+// Copyright 2023-2024 Chartboost, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+import ChartboostSDK
+import Foundation
+
+/// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
+@objc public class ChartboostAdapterConfiguration: NSObject {
+
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        Chartboost.getSDKVersion()
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.9.7.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "chartboost"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "Chartboost"
+}


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.