### PR TITLE
HB-7607: Replace duplicated code with call to helper method

### DIFF
--- a/Source/ChartboostAdapterConfiguration.swift
+++ b/Source/ChartboostAdapterConfiguration.swift
@@ -17,7 +17,7 @@ import Foundation
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc public static let adapterVersion = "4.9.7.0.0"
+    @objc public static let adapterVersion = "5.9.7.0.0"
 
     /// The partner's unique identifier.
     @objc public static let partnerID = "chartboost"


### PR DESCRIPTION
Many adapters have similar code for finding the largest standard banner size that will fit within requested dimensions. This can now be replaced with BannerSize.largestStandardFixedSizeThatFits(in:)